### PR TITLE
#20.4 extract_itemの結果が不正でないか確認するvalidation関数を生成

### DIFF
--- a/tests/test_validates.py
+++ b/tests/test_validates.py
@@ -1,0 +1,44 @@
+from vook_db_v4.extract_item import extract_item_denim, extract_item_denim_jacket
+from vook_db_v4.validates import validate_item_fullmatch
+
+
+def test_valid_item_denim():
+    ret = "denim"
+    item_name = "リーバイス 40s VINTAGE 501XX 革パッチ 片面タブ デニムパンツ ヴィンテージ インディゴ"
+    func = extract_item_denim
+    actual = validate_item_fullmatch(ret, item_name, func)
+    expected = None
+    assert actual == expected
+
+
+def test_valid_item_denim_jacket():
+    ret = "denim jacket"
+    item_name = (
+        "リーバイス ジージャン Ｇジャン Levi's 米国製 70579 バレンシア工場製造 リジッド デニムジャケット MADE IN THE USA"
+    )
+    func = extract_item_denim_jacket
+    actual = validate_item_fullmatch(ret, item_name, func)
+    expected = None
+    assert actual == expected
+
+
+def test_valid_item_denim_none():
+    ret = None
+    item_name = (
+        "Levi's リーバイス 1950 Levi's Vintage Big Poster ヴィンテージビッグポスター 広告用 ビンテージ ビッグサイズ"
+    )
+    func = extract_item_denim
+    actual = validate_item_fullmatch(ret, item_name, func)
+    expected = None
+    assert actual == expected
+
+
+def test_valid_item_denim_jacket_none():
+    ret = None
+    item_name = (
+        "リーバイス ジージャン Ｇジャン Levi's 米国製 70579 バレンシア工場製造 リジッド デニムジャケット MADE IN THE USA"
+    )
+    func = extract_item_denim_jacket
+    actual = validate_item_fullmatch(ret, item_name, func)
+    expected = None
+    assert actual == expected

--- a/vook_db_v4/validates.py
+++ b/vook_db_v4/validates.py
@@ -7,3 +7,12 @@ def validate_19XX_fullmatch(
 ) -> None:
     if not re.fullmatch(r"19\d{2}", ret[0]) or not re.fullmatch(r"19\d{2}", ret[1]):
         raise Exception(f"\nitem_name: {item_name}\nvalue: {ret}\nfuncions: {func}")
+
+
+def validate_item_fullmatch(
+    ret: str, item_name: str, func: Callable[[str], str]
+) -> None:
+    if not ret:
+        return None
+    if not re.fullmatch(r"denim|denim\sjacket", ret):
+        raise Exception(f"\nitem_name: {item_name}\nvalue: {ret}\nfuncions: {func}")


### PR DESCRIPTION
# Issue

- close #28 

# 変更の目的

- 不正な値の検出

# 変更内容

- validate_item_fullmatch関数の新規作成

# 変更によって期待される結果

- 不正な値の検出によってproductsテーブルに想定外の値が格納されない
